### PR TITLE
Add support for Philips 3435731P7

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -1877,6 +1877,15 @@ module.exports = [
         extend: hueExtend.light_onoff_brightness_colortemp({colorTempRange: [153, 454]}),
         ota: ota.zigbeeOTA,
     },
+    {                                                                                                                       
+        zigbeeModel: ['LTW018'],                                                                                         
+        model: '3435731P7',                                                                                                 
+        vendor: 'Philips',                                                                                                  
+        description: 'Hue Adore white ambiance bathroom mirror',                                                                           
+        meta: {turnsOffAtBrightness1: true},                                                                                
+        extend: hueExtend.light_onoff_brightness_colortemp({colorTempRange: [153, 454]}),                                   
+        ota: ota.zigbeeOTA,                                                                                                 
+    },
     {
         zigbeeModel: ['LCX002'],
         model: '929002422801',


### PR DESCRIPTION
Add support for Philips 3435731P7 Hue Adore white ambiance bathroom mirror.
Functionality identical to Phillips 3418631P6.